### PR TITLE
FG-BUG-03: Make Jest handle XSLT imports without breaking the system

### DIFF
--- a/__mocks__/xsltMock.js
+++ b/__mocks__/xsltMock.js
@@ -1,0 +1,1 @@
+module.exports = "xslt-stub";

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,6 @@
 module.exports = {
-  preset: "@vue/cli-plugin-unit-jest"
+  preset: "@vue/cli-plugin-unit-jest",
+  moduleNameMapper: {
+    "^.+\\.xslt$": "<rootDir>/__mocks__/xsltMock.js"
+  }
 };

--- a/src/mixins/xslt.js
+++ b/src/mixins/xslt.js
@@ -1,13 +1,17 @@
 /* eslint-disable import/prefer-default-export */
 
-export const getXsltPath = (xsltName) => {
+import * as LettersMsDescXslt from "@/assets/xslt/LettersMsDesc.xslt";
+import * as LettersTextXslt from "@/assets/xslt/LettersText.xslt";
+import * as WorkTitleXslt from "@/assets/xslt/WorkTitle.xslt";
+
+export const getXslt = (xsltName) => {
   switch (xsltName) {
     case "LettersMsDesc":
-      return "@/assets/xslt/LettersMsDesc.xslt";
+      return LettersMsDescXslt;
     case "LettersText":
-      return "@/assets/xslt/LettersText.xslt";
+      return LettersTextXslt;
     case "WorkTitle":
-      return "@/assets/xslt/WorkTitle.xslt";
+      return WorkTitleXslt;
     default:
       throw new Error("XSLT not implemented");
   }
@@ -16,8 +20,7 @@ export const getXsltPath = (xsltName) => {
 
 export const processXML = async(xmlString, xsltName) => {
   try {
-    // const stylesheetModule = await import(getXsltPath(xsltName));
-    const stylesheetModule = await import(`@/assets/xslt/${xsltName}.xslt`);
+    const stylesheetModule = getXslt(xsltName);
     const xsltStylesheet = stylesheetModule.default;
     const parser = new DOMParser();
     const xmlParsed = parser.parseFromString(xmlString, "text/xml");
@@ -35,7 +38,7 @@ export const processXML = async(xmlString, xsltName) => {
 
 export const xslt = {
   methods: {
-    getXsltPath,
+    getXslt,
     processXML
   }
 };

--- a/src/shared/service.js
+++ b/src/shared/service.js
@@ -90,7 +90,6 @@ const getSearchResults = async function(entityName, searchInput) {
 const XSLTransform = async function(path, xsltName) {
   try {
     const stylesheetModule = xslt.methods.getXslt(xsltName);
-    // const stylesheetModule = await import(`@/assets/xslt/${xsltName}.xslt`);
     const stylesheet = stylesheetModule.default;
     const response = await axios.post(`${API}${path}`, stylesheet, {
       params: {

--- a/src/shared/service.js
+++ b/src/shared/service.js
@@ -89,8 +89,8 @@ const getSearchResults = async function(entityName, searchInput) {
 
 const XSLTransform = async function(path, xsltName) {
   try {
-    // const stylesheetModule = await import(xslt.methods.getXsltPath(xsltName));
-    const stylesheetModule = await import(`@/assets/xslt/${xsltName}.xslt`);
+    const stylesheetModule = xslt.methods.getXslt(xsltName);
+    // const stylesheetModule = await import(`@/assets/xslt/${xsltName}.xslt`);
     const stylesheet = stylesheetModule.default;
     const response = await axios.post(`${API}${path}`, stylesheet, {
       params: {


### PR DESCRIPTION
## Issue

Dynamic importing is not possible. You should always use scalar values. 

To make Jest run, we introduced a switch case to get the correct XSLT path.

## What changed?

We now mock it correctly for Jest.